### PR TITLE
Improve CanIUse data parsing

### DIFF
--- a/tasks/start-template.html
+++ b/tasks/start-template.html
@@ -54,7 +54,7 @@
 				? `<div class="cssdb-feature-caniuse" aria-hidden="true">
 					${Object.keys(feature.caniuse.stats).map(
 						(id) => `<span class="cssdb-browser cssdb-browser--${id}">${Object.keys(feature.caniuse.stats[id]).filter(
-							(version) => feature.caniuse.stats[id][version] === 'y'
+							(version) => feature.caniuse.stats[id][version].indexOf('y') === 0
 						).slice(0, 1).map(
 							(version) => `<span class="cssdb-browser-version">${version}</span>`
 						)}</span>`


### PR DESCRIPTION
The caniuse-lite data for some supported features have extra notes after the `y` character (e.g. for the `:matches()` CSS pseudo-class the data for Safari 9+ reports `"y #2"`, referring to the note that _except_ the _full_ support of `:matches()` these browsers _also_ support the old prefixed version). Because of the strict comparison with `'y'`, these features were reported as non-supported, which doesn't seem correct to me.