### PR TITLE
add break-* properties

### DIFF
--- a/cssdb.json
+++ b/cssdb.json
@@ -1,5 +1,19 @@
 [
   {
+    "title": "Box `break-*` properties",
+    "description": "Controlling breaks between and within boxes",
+    "specification": "https://www.w3.org/TR/css-break-3/#breaking-controls",
+    "specificationId": "css-break",
+    "stage": 4,
+    "example": "a {\n  break-inside: avoid;\n  break-before: avoid-column;\n  break-after: always;\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/shrpne/postcss-page-break"
+      }
+    ]
+  },
+  {
     "title": "Cascade `all` Property",
     "description": "A property for defining the reset of all properties of an element",
     "specification": "https://www.w3.org/TR/css-cascade-3/#all-shorthand",


### PR DESCRIPTION
This feature is needed for https://github.com/jonathantneal/postcss-preset-env/issues/11

Please review it:
- I'm not sure that I choose correct `specificationId`. Because it includes [break-between](https://www.w3.org/TR/css-break-3/#break-between) and [break-within](https://www.w3.org/TR/css-break-3/#break-within) and not includes [widows-orphans](https://www.w3.org/TR/css-break-3/#widows-orphans)
- I'm not sure which `caniuse` feature chose. There are [multicolumn](https://caniuse.com/#feat=multicolumn) and [css-page-break](https://caniuse.com/#feat=css-page-break) and they both partially covers `break-` 
